### PR TITLE
feat(syntax): support comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "t",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "A basic language used to explore compiler design techniques.",
   "main": "lib/index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -36,10 +36,10 @@ Options:
 ### Variables
 
 ```
-; immutable
+# immutable
 let x = 10
 
-; mutable
+# mutable
 mut x = 10
 ```
 
@@ -70,10 +70,10 @@ mut x = 0
 mut y: num? = nil
 
 if y != nil {
-  ; y has a type of `num` here.
+  # y has a type of `num` here.
   x = x + y
 } else {
-  ; y has a type of `nil` here.
+  # y has a type of `nil` here.
 }
 ```
 
@@ -97,7 +97,7 @@ Because the index used to access the array may be outside the length of the arra
 let first_element = my_array[0] ; first_element is `num?` here.
 
 if first_element != nil {
-  ; first_element is `num` here.
+  # first_element is `num` here.
 }
 ```
 

--- a/src/ast/syntax-node.ts
+++ b/src/ast/syntax-node.ts
@@ -36,8 +36,13 @@ export const enum SyntaxNodeFlags {
  * Types of syntax which can appear in a source file of t.
  */
 export enum SyntaxKind {
+  // markers or thrown away tokens.
   EndOfFileToken,
   UnknownToken,
+  Comment,
+
+  // marker
+  FirstToken,
 
   // keywords
   LetKeyword,

--- a/src/ast/token.ts
+++ b/src/ast/token.ts
@@ -12,6 +12,7 @@ export interface SyntaxToken<TokenKind extends TokenSyntaxKind> extends SyntaxNo
 export type TokenSyntaxKind
   = SyntaxKind.EndOfFileToken
   | SyntaxKind.UnknownToken
+  | SyntaxKind.Comment
   | SyntaxKind.StructKeyword
   | SyntaxKind.PlusToken
   | SyntaxKind.MinusToken

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -95,6 +95,18 @@ export function createLexer(src: string): Lexer {
         return createToken(SyntaxKind.EndOfFileToken, { pos, end: pos });
       }
 
+      // comments
+      if (src[pos] === '#') {
+        // consume until the end of the line.
+        const start = pos;
+        do {
+          pos++;
+        } while (!atEnd() && src[pos] !== '\n');
+        // skip the newline.
+        pos++;
+        return createToken(SyntaxKind.Comment, { pos: start, end: pos });
+      }
+
       // numbers
       if (digit.test(src[pos])) {
         const start = pos;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -79,9 +79,10 @@ export function createParser(source: SourceFile): Parser {
 
   while (true) {
     const token = lexer.nextToken();
-    // skip unknown tokens, they will just cause
-    // superfluous diagnostic messages.
-    if (token.kind !== SyntaxKind.UnknownToken) {
+    // skip any tokens before the FirstToken
+    // marker. These tokens are superfluous
+    // and will causes more diagnostic messages.
+    if (token.kind > SyntaxKind.FirstToken) {
       tokens.push(token);
     }
     if (token.kind === SyntaxKind.EndOfFileToken) {


### PR DESCRIPTION
Adds comment support to the lexer/parser.

Only line comments are supported, they begin with a `#` and run all the way to the end of the line.