### PR TITLE
fix(types): fix some typos in type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "t",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A basic language used to explore compiler design techniques.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/bind/global-symbol-table.ts
+++ b/src/bind/global-symbol-table.ts
@@ -18,7 +18,7 @@ export function createGlobalTypeTable(): ScopedMap<string, SymbolType> {
   numNode.symbol = numSymbol;
 
   const boolNode = createSyntheticIdentifier('bool');
-  const boolSymbol = createTypeSymbol(numNode.value, numNode);
+  const boolSymbol = createTypeSymbol(boolNode.value, boolNode);
   boolNode.symbol = boolSymbol;
 
   const strNode = createSyntheticIdentifier('str');

--- a/src/typecheck/global-type-table.ts
+++ b/src/typecheck/global-type-table.ts
@@ -21,8 +21,8 @@ export function createGlobalTypeTable(): ScopedMap<string, Type> {
 
   const addOpName = binaryOpName[SyntaxKind.PlusToken];
   const subOpName = binaryOpName[SyntaxKind.MinusToken];
-  const mulOpName = binaryOpName[SyntaxKind.PlusToken];
-  const divOpName = binaryOpName[SyntaxKind.MinusToken];
+  const mulOpName = binaryOpName[SyntaxKind.StarToken];
+  const divOpName = binaryOpName[SyntaxKind.SlashToken];
 
   const ltOpName = binaryOpName[SyntaxKind.LessThan];
   const gtOpName = binaryOpName[SyntaxKind.GreaterThan];


### PR DESCRIPTION
Fixes a few typos which were causing the boolean type and some binary operators to not be recognised properly.