### PR TITLE
Add some examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
+# dependencies
 node_modules/
+
+# build artifacts
 lib/
 tsconfig.tsbuildinfo
 
 # random test files
 *.t
+
+# allow t files in example dir
+!examples/*.t
 
 # editors
 .vscode/

--- a/examples/control-flow.t
+++ b/examples/control-flow.t
@@ -1,0 +1,20 @@
+fn main(): nil {
+  # if/else is supported, brackets are not requied.
+  if some_condition {
+    do_something()
+  } else {
+    do_other_thing()
+  }
+
+  # loop and stop can be used to create loops. There
+  # is no syntax for for loops yet, so they must be
+  # created using a local variable and a loop.
+  mut i = 0
+  loop {
+    i = i + 1
+    if i > 10 {
+      stop
+    }
+    print('iteration ' + to_string(i))
+  }
+}

--- a/examples/fibonacci.t
+++ b/examples/fibonacci.t
@@ -1,0 +1,14 @@
+fn main(): nil {
+  # first 10 fibonacci numbers.
+  let result = fib(10)
+}
+
+# function return types can be inferred, but
+# because this function is recursive it requires
+# a return type annotation.
+fn fib(n: num): num {
+  if n < 2 {
+    return n
+  }
+  return fib(n - 1) + fib(n - 2)
+}

--- a/examples/primitive-types.t
+++ b/examples/primitive-types.t
@@ -1,0 +1,19 @@
+fn main(a: num, b:num): nil {
+  # The primitive types in t are num, str and bool.
+  # num supports all of the ususal operators.
+  let sum: num = 1 + 2 * 3 / (2 - 1)
+
+  # str only addition (concatenation).
+  let str_err = 'hello' - 'world'
+  # error: The type str does not support the "-" operator.
+  #  --> in examples/primitive-types.t
+  #   |
+  # 7 |   let str_err = 'hello' - 'world'
+  #   |                 ^^^^^^^^^
+
+  # bool can be used for boolean types.
+  let some_condition: bool = true
+
+  # comparisons work between numbers.
+  let small_sum = sum < 100
+}

--- a/examples/struct-declarations.t
+++ b/examples/struct-declarations.t
@@ -1,0 +1,25 @@
+# structs can be declared using the struct keyword
+# by default, all struct members are immutable.
+struct Point {
+  x: num,
+  y: num,
+}
+
+# struct members can be made mutable by
+# using the `mut` keyword.
+struct MutablePoint {
+  mut x: num,
+  mut y: num,
+}
+
+fn main(): nil {
+  # struct instances can be created by using the `new` keyword.
+  let p = new Point { x: 10, y: 20 }
+
+  # error, cannot assign to immutable struct members.
+  p.x = 10
+
+  # this works fine because the members are mutable.
+  let p_mut = new MutablePoint { x: 10, y: 20 }
+  p_mut.x = 20
+}


### PR DESCRIPTION
This PR adds some examples of the language to the `examples/` directory. Some of these examples do not yet compile because the syntax is not recognised. However, the compiler should eventually be able to compile all of these examples without errors.